### PR TITLE
Update wp-cache-phase2.php

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1063,7 +1063,7 @@ function wp_cache_get_postid_from_comment( $comment_id, $status = 'NA' ) {
 			define( 'DONOTDELETECACHE', 1 );
 			return $postid;
 		} elseif( $comment['comment_approved'] == '0' ) {
-			if ( $comment[ 'content_type' ] == '' ) {
+			if ( $comment[ 'comment_type' ] == '' ) {
 				wp_cache_debug( "Moderated comment. Don't delete supercache file until comment approved.", 4 );
 				$super_cache_enabled = 0; // don't remove the super cache static file until comment is approved
 				define( 'DONOTDELETECACHE', 1 );


### PR DESCRIPTION
When using moderated comments, I kept getting the message:
PHP Notice:  Undefined index: content_type in {wordpress_directory}\wp-content\plugins\wp-super-cache\wp-cache-phase2.php on line 1004  (I'm currently using version 1.4.9)
Reviewing the return object from get_comment() ( https://codex.wordpress.org/Function_Reference/get_comment ) states that this method should not yield an array containing 'content_type' as a key.  Instead maybe, the correct key should be 'comment_type'?  (idk, not my circus not my monkeys)  This exception would cause the rest of the code block to be skipped.